### PR TITLE
arm64: Runtime enableable pseudo-NMI

### DIFF
--- a/arch/arm64/Kconfig
+++ b/arch/arm64/Kconfig
@@ -2280,6 +2280,24 @@ config ARM64_PSEUDO_NMI
 	  If unsure, say N
 
 if ARM64_PSEUDO_NMI
+config ARM64_RUNTIME_PSEUDO_NMI
+	bool "Runtime enableable pseudo-NMI"
+	select DEBUG_FS
+	help
+	  Allow pseudo-NMI to be enabled and disabled at runtime via debugfs
+	  instead of requiring the irqchip.gicv3_pseudo_nmi=1 boot parameter.
+
+	  When this option is selected, pseudo-NMI is not activated at boot.
+	  It can be enabled later by writing to
+	  /sys/kernel/debug/pseudo_nmi/enable, which switches interrupt
+	  masking from DAIF to PMR and promotes debug IPIs to NMI priority.
+
+	  This is useful for on-demand debugging of hard lockups and other
+	  situations where NMI backtraces are needed without paying the PMR
+	  masking overhead at all times.
+
+	  If unsure, say N
+
 config ARM64_DEBUG_PRIORITY_MASKING
 	bool "Debug interrupt priority masking"
 	help

--- a/arch/arm64/include/asm/arch_gicv3.h
+++ b/arch/arm64/include/asm/arch_gicv3.h
@@ -188,5 +188,11 @@ static inline bool gic_has_relaxed_pmr_sync(void)
 	return cpus_have_cap(ARM64_HAS_GIC_PRIO_RELAXED_SYNC);
 }
 
+#ifdef CONFIG_ARM64_RUNTIME_PSEUDO_NMI
+bool gic_runtime_nmi_forbidden(void);
+void gic_runtime_enable_nmi(void);
+void gic_runtime_disable_nmi(void);
+#endif
+
 #endif /* __ASSEMBLER__ */
 #endif /* __ASM_ARCH_GICV3_H */

--- a/arch/arm64/include/asm/cpufeature.h
+++ b/arch/arm64/include/asm/cpufeature.h
@@ -804,8 +804,13 @@ static inline bool system_has_full_ptr_auth(void)
 	return system_supports_address_auth() && system_supports_generic_auth();
 }
 
+DECLARE_STATIC_KEY_FALSE(arm64_irq_prio_masking);
+
 static __always_inline bool system_uses_irq_prio_masking(void)
 {
+	if (IS_ENABLED(CONFIG_ARM64_RUNTIME_PSEUDO_NMI) &&
+	    !__is_defined(__KVM_NVHE_HYPERVISOR__))
+		return static_branch_unlikely(&arm64_irq_prio_masking);
 	return alternative_has_cap_unlikely(ARM64_HAS_GIC_PRIO_MASKING);
 }
 

--- a/arch/arm64/include/asm/jump_label.h
+++ b/arch/arm64/include/asm/jump_label.h
@@ -58,5 +58,21 @@ l_yes:
 	return true;
 }
 
+#else /* __ASSEMBLER__ */
+
+/*
+ * Branch to \target when static key \key is disabled (false).
+ * Patched to NOP when \key is enabled, falling through to the next
+ * instruction.
+ */
+.macro	STATIC_BRANCH_DISABLE	key, target
+1:	b	\target
+	.pushsection	__jump_table, "aw"
+	.align	3
+	.long	1b - ., \target - .
+	.quad	\key + 1 - .
+	.popsection
+.endm
+
 #endif  /* __ASSEMBLER__ */
 #endif	/* __ASM_JUMP_LABEL_H */

--- a/arch/arm64/include/asm/smp.h
+++ b/arch/arm64/include/asm/smp.h
@@ -77,6 +77,12 @@ static inline void set_smp_ipi_range(int ipi_base, int n)
 	set_smp_ipi_range_percpu(ipi_base, n, 0);
 }
 
+#ifdef CONFIG_ARM64_RUNTIME_PSEUDO_NMI
+void init_gic_priority_masking_cpu(void *data);
+int ipi_promote_to_nmi(void);
+void ipi_demote_from_nmi(void);
+#endif
+
 /*
  * Called from the secondary holding pen, this is the secondary CPU entry point.
  */

--- a/arch/arm64/kernel/Makefile
+++ b/arch/arm64/kernel/Makefile
@@ -69,6 +69,7 @@ obj-$(CONFIG_ARM_SDE_INTERFACE)		+= sdei.o
 obj-$(CONFIG_ARM64_PTR_AUTH)		+= pointer_auth.o
 obj-$(CONFIG_ARM64_MPAM)		+= mpam.o
 obj-$(CONFIG_ARM64_MTE)			+= mte.o
+obj-$(CONFIG_ARM64_RUNTIME_PSEUDO_NMI)	+= pseudo_nmi.o
 obj-y					+= vdso-wrap.o
 obj-$(CONFIG_COMPAT_VDSO)		+= vdso32-wrap.o
 

--- a/arch/arm64/kernel/cpufeature.c
+++ b/arch/arm64/kernel/cpufeature.c
@@ -1133,6 +1133,9 @@ static void init_32bit_cpu_features(struct cpuinfo_32bit *info)
 }
 
 #ifdef CONFIG_ARM64_PSEUDO_NMI
+DEFINE_STATIC_KEY_FALSE(arm64_irq_prio_masking);
+EXPORT_SYMBOL(arm64_irq_prio_masking);
+
 static bool enable_pseudo_nmi;
 
 static int __init early_enable_pseudo_nmi(char *p)
@@ -2273,6 +2276,9 @@ static bool can_use_gic_priorities(const struct arm64_cpu_capabilities *entry,
 	 */
 	BUILD_BUG_ON(ARM64_HAS_GIC_PRIO_MASKING <= ARM64_HAS_GICV3_CPUIF);
 	if (!cpus_have_cap(ARM64_HAS_GICV3_CPUIF))
+		return false;
+
+	if (IS_ENABLED(CONFIG_ARM64_RUNTIME_PSEUDO_NMI))
 		return false;
 
 	return enable_pseudo_nmi;

--- a/arch/arm64/kernel/entry.S
+++ b/arch/arm64/kernel/entry.S
@@ -17,6 +17,7 @@
 #include <asm/asm_pointer_auth.h>
 #include <asm/bug.h>
 #include <asm/cpufeature.h>
+#include <asm/jump_label.h>
 #include <asm/errno.h>
 #include <asm/esr.h>
 #include <asm/irq.h>
@@ -310,9 +311,13 @@ alternative_else_nop_endif
 	.endif
 
 #ifdef CONFIG_ARM64_PSEUDO_NMI
+#ifdef CONFIG_ARM64_RUNTIME_PSEUDO_NMI
+	STATIC_BRANCH_DISABLE arm64_irq_prio_masking, .Lskip_pmr_save\@
+#else
 alternative_if_not ARM64_HAS_GIC_PRIO_MASKING
 	b	.Lskip_pmr_save\@
 alternative_else_nop_endif
+#endif
 
 	mrs_s	x20, SYS_ICC_PMR_EL1
 	str	w20, [sp, #S_PMR]
@@ -338,9 +343,13 @@ alternative_else_nop_endif
 	.endif
 
 #ifdef CONFIG_ARM64_PSEUDO_NMI
+#ifdef CONFIG_ARM64_RUNTIME_PSEUDO_NMI
+	STATIC_BRANCH_DISABLE arm64_irq_prio_masking, .Lskip_pmr_restore\@
+#else
 alternative_if_not ARM64_HAS_GIC_PRIO_MASKING
 	b	.Lskip_pmr_restore\@
 alternative_else_nop_endif
+#endif
 
 	ldr	w20, [sp, #S_PMR]
 	msr_s	SYS_ICC_PMR_EL1, x20

--- a/arch/arm64/kernel/pseudo_nmi.c
+++ b/arch/arm64/kernel/pseudo_nmi.c
@@ -1,0 +1,265 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * Runtime pseudo-NMI enable/disable support.
+ *
+ * Copyright (C) 2026 Puranjay Mohan <puranjay@kernel.org>
+ */
+
+#include <linux/debugfs.h>
+#include <linux/irqflags.h>
+#include <linux/jump_label.h>
+#include <linux/mutex.h>
+#include <linux/smp.h>
+#include <asm-generic/irq_regs.h>
+
+#include <asm/arch_gicv3.h>
+#include <asm/cpufeature.h>
+#include <asm/daifflags.h>
+#include <asm/smp.h>
+
+static DEFINE_MUTEX(pnmi_lock);
+static bool pnmi_enabled;
+
+static atomic_t pnmi_parked_cpus;
+static atomic_t pnmi_patch_done;
+
+/*
+ * IPI handler for remote CPUs during the masking paradigm switch.
+ *
+ * Remote CPUs park here with IRQs disabled (IPI context), wait for
+ * the master to finish patching, then perform the lock-new/unlock-old
+ * transition atomically.
+ */
+static void pnmi_enable_remote(void *data)
+{
+	struct pt_regs *regs = get_irq_regs();
+
+	atomic_inc(&pnmi_parked_cpus);
+
+	while (!atomic_read(&pnmi_patch_done))
+		cpu_relax();
+	/* Pairs with smp_wmb() in pnmi_switch_to_pmr() */
+	smp_rmb();
+	isb();
+
+	gic_write_pmr(GIC_PRIO_IRQOFF);
+	write_sysreg(DAIF_PROCCTX, daif);
+
+	/*
+	 * kernel_entry ran before the switch and did not save PMR.
+	 * kernel_exit will run after and will try to restore it.
+	 * Convert the DAIF-format saved state to the correct PMR value
+	 * so kernel_exit writes a valid PMR on return.
+	 */
+	if (regs) {
+		if (regs->pstate & PSR_I_BIT)
+			regs->pmr = GIC_PRIO_IRQOFF;
+		else
+			regs->pmr = GIC_PRIO_IRQON;
+	}
+}
+
+static void pnmi_disable_remote(void *data)
+{
+	struct pt_regs *regs = get_irq_regs();
+
+	atomic_inc(&pnmi_parked_cpus);
+
+	while (!atomic_read(&pnmi_patch_done))
+		cpu_relax();
+	/* Pairs with smp_wmb() in pnmi_switch_to_daif() */
+	smp_rmb();
+	isb();
+
+	asm volatile("msr daifset, #3" ::: "memory");
+	gic_write_pmr(GIC_PRIO_IRQON);
+
+	/*
+	 * kernel_entry saved PMR but kernel_exit will skip restoring it.
+	 * In pNMI mode DAIF.I was clear when IRQs were "disabled" via PMR.
+	 * Convert the PMR-format state to DAIF-format by setting PSR.I in
+	 * the saved pstate if PMR indicated IRQs were masked.
+	 */
+	if (regs && regs->pmr != GIC_PRIO_IRQON)
+		regs->pstate |= PSR_I_BIT | PSR_F_BIT;
+}
+
+static void pnmi_wait_for_park(void)
+{
+	int expected = num_online_cpus() - 1;
+
+	while (atomic_read(&pnmi_parked_cpus) < expected)
+		cpu_relax();
+	/* Pairs with atomic_inc() in pnmi_{enable,disable}_remote() */
+	smp_rmb();
+}
+
+/*
+ * Switch the interrupt masking paradigm between DAIF and PMR.
+ *
+ * The transition must be atomic across all call sites on all CPUs.
+ * Remote CPUs are parked via IPI with interrupts disabled while the
+ * master CPU patches all static branch sites under jump_label_lock.
+ *
+ * The lock-new/unlock-old pattern ensures no CPU ever has both masks
+ * active simultaneously: we take the new lock before unlocking the
+ * old one on each CPU, and all patching completes before any CPU
+ * unlocks.
+ */
+static void pnmi_switch_to_pmr(void)
+{
+	atomic_set(&pnmi_parked_cpus, 0);
+	atomic_set(&pnmi_patch_done, 0);
+
+	jump_label_lock();
+
+	smp_call_function(pnmi_enable_remote, NULL, 0);
+	pnmi_wait_for_park();
+
+	local_irq_disable();
+
+	/* Master: lock-new */
+	init_gic_priority_masking_cpu(NULL);
+	gic_write_pmr(GIC_PRIO_IRQOFF);
+
+	/* Master: patch all sites */
+	atomic_set(&arm64_irq_prio_masking.key.enabled, 1);
+	jump_label_update_nosync(&arm64_irq_prio_masking.key);
+
+	/* Ensure text patches are visible before releasing parked CPUs */
+	smp_wmb();
+	atomic_set(&pnmi_patch_done, 1);
+
+	isb();
+
+	/* Master: unlock-old, enable IRQs through new PMR path */
+	trace_hardirqs_on();
+	write_sysreg(DAIF_PROCCTX, daif);
+	gic_write_pmr(GIC_PRIO_IRQON);
+	pmr_sync();
+
+	jump_label_unlock();
+}
+
+static void pnmi_switch_to_daif(void)
+{
+	atomic_set(&pnmi_parked_cpus, 0);
+	atomic_set(&pnmi_patch_done, 0);
+
+	jump_label_lock();
+
+	smp_call_function(pnmi_disable_remote, NULL, 0);
+	pnmi_wait_for_park();
+
+	/* Master: lock-old (disable via both DAIF and PMR for safety) */
+	local_irq_disable();
+	asm volatile("msr daifset, #3" ::: "memory");
+
+	/* Master: patch all sites */
+	atomic_set(&arm64_irq_prio_masking.key.enabled, 0);
+	jump_label_update_nosync(&arm64_irq_prio_masking.key);
+
+	/* Ensure text patches are visible before releasing parked CPUs */
+	smp_wmb();
+	atomic_set(&pnmi_patch_done, 1);
+
+	isb();
+
+	/* Master: unlock-new, enable IRQs through old DAIF path */
+	trace_hardirqs_on();
+	gic_write_pmr(GIC_PRIO_IRQON);
+	write_sysreg(DAIF_PROCCTX, daif);
+
+	jump_label_unlock();
+}
+
+static int pseudo_nmi_enable(void)
+{
+	int ret;
+
+	if (gic_runtime_nmi_forbidden())
+		return -ENODEV;
+
+	cpus_read_lock();
+
+	pnmi_switch_to_pmr();
+	gic_runtime_enable_nmi();
+
+	ret = ipi_promote_to_nmi();
+	if (ret) {
+		gic_runtime_disable_nmi();
+		pnmi_switch_to_daif();
+		cpus_read_unlock();
+		return ret;
+	}
+
+	cpus_read_unlock();
+
+	pr_info("Pseudo-NMI enabled at runtime\n");
+	return 0;
+}
+
+static void pseudo_nmi_disable(void)
+{
+	cpus_read_lock();
+
+	ipi_demote_from_nmi();
+	gic_runtime_disable_nmi();
+	pnmi_switch_to_daif();
+
+	cpus_read_unlock();
+
+	pr_info("Pseudo-NMI disabled at runtime\n");
+}
+
+static ssize_t pnmi_write(struct file *file, const char __user *ubuf,
+			   size_t count, loff_t *ppos)
+{
+	bool val;
+	int ret;
+
+	ret = kstrtobool_from_user(ubuf, count, &val);
+	if (ret)
+		return ret;
+
+	guard(mutex)(&pnmi_lock);
+
+	if (val == pnmi_enabled)
+		return count;
+
+	if (val)
+		ret = pseudo_nmi_enable();
+	else
+		pseudo_nmi_disable();
+
+	if (!ret)
+		pnmi_enabled = val;
+
+	return ret ?: count;
+}
+
+static ssize_t pnmi_read(struct file *file, char __user *ubuf,
+			  size_t count, loff_t *ppos)
+{
+	char buf[4];
+	int len;
+
+	len = scnprintf(buf, sizeof(buf), "%d\n", pnmi_enabled);
+	return simple_read_from_buffer(ubuf, count, ppos, buf, len);
+}
+
+static const struct file_operations pnmi_fops = {
+	.write	= pnmi_write,
+	.read	= pnmi_read,
+};
+
+static int __init pseudo_nmi_debugfs_init(void)
+{
+	struct dentry *dir;
+
+	dir = debugfs_create_dir("pseudo_nmi", NULL);
+	debugfs_create_file("enable", 0600, dir, NULL, &pnmi_fops);
+
+	return 0;
+}
+late_initcall(pseudo_nmi_debugfs_init);

--- a/arch/arm64/kernel/smp.c
+++ b/arch/arm64/kernel/smp.c
@@ -188,6 +188,13 @@ static void init_gic_priority_masking(void)
 	gic_write_pmr(GIC_PRIO_IRQON | GIC_PRIO_PSR_I_SET);
 }
 
+#ifdef CONFIG_ARM64_RUNTIME_PSEUDO_NMI
+void init_gic_priority_masking_cpu(void *data)
+{
+	init_gic_priority_masking();
+}
+#endif
+
 /*
  * This is the secondary CPU boot entry.  We're using this CPUs
  * idle thread stack, but a set of temporary page tables.
@@ -1147,6 +1154,111 @@ void __init set_smp_ipi_range_percpu(int ipi_base, int n, int ncpus)
 	/* Setup the boot CPU immediately */
 	ipi_setup(smp_processor_id());
 }
+
+#ifdef CONFIG_ARM64_RUNTIME_PSEUDO_NMI
+static void disable_percpu_irq_cb(void *data)
+{
+	disable_percpu_irq((unsigned long)data);
+}
+
+static void enable_percpu_irq_cb(void *data)
+{
+	enable_percpu_irq((unsigned long)data, 0);
+}
+
+static void setup_percpu_nmi_cb(void *data)
+{
+	unsigned long irq = (unsigned long)data;
+
+	prepare_percpu_nmi(irq);
+	enable_percpu_nmi(irq, 0);
+}
+
+static void teardown_percpu_nmi_cb(void *data)
+{
+	unsigned long irq = (unsigned long)data;
+
+	disable_percpu_nmi(irq);
+	teardown_percpu_nmi(irq);
+}
+
+static int ipi_promote_one(int ipi)
+{
+	int irq = ipi_irq_base + ipi;
+	int err;
+
+	on_each_cpu(disable_percpu_irq_cb, (void *)(unsigned long)irq, 1);
+	free_percpu_irq(irq, &irq_stat);
+
+	err = request_percpu_nmi(irq, ipi_handler, "IPI", NULL, &irq_stat);
+	if (err) {
+		int err2;
+
+		pr_err("Failed to promote IPI %d to NMI: %d\n", ipi, err);
+		err2 = request_percpu_irq(irq, ipi_handler, "IPI", &irq_stat);
+		WARN_ON(err2);
+		on_each_cpu(enable_percpu_irq_cb,
+			    (void *)(unsigned long)irq, 1);
+		return err;
+	}
+
+	on_each_cpu(setup_percpu_nmi_cb, (void *)(unsigned long)irq, 1);
+	return 0;
+}
+
+static void ipi_demote_one(int ipi)
+{
+	int irq = ipi_irq_base + ipi;
+	int err;
+
+	on_each_cpu(teardown_percpu_nmi_cb, (void *)(unsigned long)irq, 1);
+	free_percpu_nmi(irq, &irq_stat);
+
+	err = request_percpu_irq(irq, ipi_handler, "IPI", &irq_stat);
+	WARN_ON(err);
+	on_each_cpu(enable_percpu_irq_cb, (void *)(unsigned long)irq, 1);
+}
+
+int ipi_promote_to_nmi(void)
+{
+	int i, err;
+
+	if (percpu_ipi_descs || !ipi_irq_base)
+		return -ENODEV;
+
+	for (i = 0; i < nr_ipi; i++) {
+		if (!ipi_should_be_nmi(i))
+			continue;
+
+		err = ipi_promote_one(i);
+		if (err)
+			goto rollback;
+	}
+
+	return 0;
+
+rollback:
+	for (i--; i >= 0; i--) {
+		if (ipi_should_be_nmi(i))
+			ipi_demote_one(i);
+	}
+	return err;
+}
+
+void ipi_demote_from_nmi(void)
+{
+	int i;
+
+	if (percpu_ipi_descs || !ipi_irq_base)
+		return;
+
+	for (i = 0; i < nr_ipi; i++) {
+		if (!ipi_should_be_nmi(i))
+			continue;
+		ipi_demote_one(i);
+	}
+}
+#endif
 
 void arch_smp_send_reschedule(int cpu)
 {

--- a/drivers/irqchip/irq-gic-v3.c
+++ b/drivers/irqchip/irq-gic-v3.c
@@ -1966,6 +1966,36 @@ static void gic_enable_nmi_support(void)
 		gic_chip.flags |= IRQCHIP_SUPPORTS_NMI;
 }
 
+#ifdef CONFIG_ARM64_RUNTIME_PSEUDO_NMI
+bool gic_runtime_nmi_forbidden(void)
+{
+	return nmi_support_forbidden || !cpus_have_cap(ARM64_HAS_GICV3_CPUIF);
+}
+
+void gic_runtime_enable_nmi(void)
+{
+	lockdep_assert_cpus_held();
+	static_branch_enable_cpuslocked(&supports_pseudo_nmis);
+
+	if (static_branch_likely(&supports_deactivate_key))
+		gic_eoimode1_chip.flags |= IRQCHIP_SUPPORTS_NMI;
+	else
+		gic_chip.flags |= IRQCHIP_SUPPORTS_NMI;
+}
+
+void gic_runtime_disable_nmi(void)
+{
+	lockdep_assert_cpus_held();
+
+	if (static_branch_likely(&supports_deactivate_key))
+		gic_eoimode1_chip.flags &= ~IRQCHIP_SUPPORTS_NMI;
+	else
+		gic_chip.flags &= ~IRQCHIP_SUPPORTS_NMI;
+
+	static_branch_disable_cpuslocked(&supports_pseudo_nmis);
+}
+#endif
+
 static int __init gic_init_bases(phys_addr_t dist_phys_base,
 				 void __iomem *dist_base,
 				 struct redist_region *rdist_regs,

--- a/drivers/misc/Kconfig
+++ b/drivers/misc/Kconfig
@@ -660,4 +660,15 @@ source "drivers/misc/mchp_pci1xxxx/Kconfig"
 source "drivers/misc/keba/Kconfig"
 source "drivers/misc/amd-sbi/Kconfig"
 source "drivers/misc/rp1/Kconfig"
+
+config TEST_IRQOFF
+	tristate "Test module for IRQ-disabled spin (NOT FOR SUBMISSION)"
+	depends on ARM64_RUNTIME_PSEUDO_NMI
+	help
+	  Test module that spins with IRQs disabled on a specific CPU.
+	  With pseudo-NMI enabled, sysrq-l will show simulated_hard_lockup()
+	  in the backtrace. Without it, the CPU is invisible.
+
+	  Usage: insmod test_irqoff.ko cpu=2 duration_ms=5000
+
 endmenu

--- a/drivers/misc/Makefile
+++ b/drivers/misc/Makefile
@@ -75,3 +75,4 @@ obj-$(CONFIG_MCHP_LAN966X_PCI)	+= lan966x-pci.o
 obj-y				+= keba/
 obj-y				+= amd-sbi/
 obj-$(CONFIG_MISC_RP1)		+= rp1/
+obj-$(CONFIG_TEST_IRQOFF)	+= test_irqoff.o

--- a/drivers/misc/test_irqoff.c
+++ b/drivers/misc/test_irqoff.c
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Test module: spin with IRQs disabled on a specific CPU.
+ *
+ * Usage:
+ *   insmod test_irqoff.ko cpu=2 duration_ms=5000
+ *
+ * A kthread is pinned to the given CPU and spins with IRQs disabled
+ * for duration_ms milliseconds. The insmod returns immediately.
+ * While spinning, only an NMI can interrupt the CPU.
+ * Use sysrq-l from another terminal to test.
+ */
+
+#include <linux/module.h>
+#include <linux/kthread.h>
+#include <linux/smp.h>
+#include <linux/timekeeping.h>
+#include <linux/nmi.h>
+
+static int cpu = 1;
+module_param(cpu, int, 0444);
+
+static int duration_ms = 5000;
+module_param(duration_ms, int, 0444);
+
+static noinline void simulated_hard_lockup(ktime_t end)
+{
+	while (ktime_before(ktime_get(), end))
+		cpu_relax();
+}
+
+static int irqoff_thread(void *data)
+{
+	unsigned long flags;
+	ktime_t end;
+
+	pr_info("test_irqoff: CPU%d disabling IRQs for %d ms NOW\n",
+		smp_processor_id(), duration_ms);
+
+	end = ktime_add_ms(ktime_get(), duration_ms);
+
+	local_irq_save(flags);
+	simulated_hard_lockup(end);
+	local_irq_restore(flags);
+
+	pr_info("test_irqoff: CPU%d done\n", smp_processor_id());
+	return 0;
+}
+
+static int __init test_irqoff_init(void)
+{
+	struct task_struct *t;
+
+	if (cpu >= nr_cpu_ids || !cpu_online(cpu)) {
+		pr_err("test_irqoff: CPU%d not online\n", cpu);
+		return -EINVAL;
+	}
+
+	t = kthread_run_on_cpu(irqoff_thread, NULL, cpu, "irqoff/%d");
+	if (IS_ERR(t))
+		return PTR_ERR(t);
+
+	return 0;
+}
+
+static void __exit test_irqoff_exit(void)
+{
+}
+
+module_init(test_irqoff_init);
+module_exit(test_irqoff_exit);
+MODULE_LICENSE("GPL");
+MODULE_DESCRIPTION("Test IRQ-disabled spin for NMI testing");

--- a/include/linux/jump_label.h
+++ b/include/linux/jump_label.h
@@ -236,6 +236,8 @@ extern void static_key_enable(struct static_key *key);
 extern void static_key_disable(struct static_key *key);
 extern void static_key_enable_cpuslocked(struct static_key *key);
 extern void static_key_disable_cpuslocked(struct static_key *key);
+extern void jump_label_update(struct static_key *key);
+extern void jump_label_update_nosync(struct static_key *key);
 extern enum jump_label_type jump_label_init_type(struct jump_entry *entry);
 
 /*

--- a/kernel/jump_label.c
+++ b/kernel/jump_label.c
@@ -90,7 +90,7 @@ jump_label_sort_entries(struct jump_entry *start, struct jump_entry *stop)
 	sort(start, size, sizeof(struct jump_entry), jump_label_cmp, swapfn);
 }
 
-static void jump_label_update(struct static_key *key);
+void jump_label_update(struct static_key *key);
 
 /*
  * There are similar definitions for the !CONFIG_JUMP_LABEL case in jump_label.h.
@@ -892,7 +892,7 @@ int jump_label_text_reserved(void *start, void *end)
 	return ret;
 }
 
-static void jump_label_update(struct static_key *key)
+void jump_label_update(struct static_key *key)
 {
 	struct jump_entry *stop = __stop___jump_table;
 	bool init = system_state < SYSTEM_RUNNING;
@@ -917,6 +917,67 @@ static void jump_label_update(struct static_key *key)
 	/* if there are no users, entry can be NULL */
 	if (entry)
 		__jump_label_update(key, entry, stop, init);
+}
+
+/*
+ * Patch all jump label sites for @key without cross-CPU synchronisation.
+ *
+ * The text is patched but no kick/IPI/ISB is performed — the caller
+ * must ensure every CPU executes an ISB before using the patched code.
+ * This is intended for callers that have already parked all remote CPUs
+ * (e.g. with IRQs disabled in an IPI handler) where a kick would
+ * deadlock.
+ *
+ * Caller must hold jump_label_lock() and have set key->enabled.
+ */
+static void __jump_label_update_nosync(struct static_key *key,
+				       struct jump_entry *entry,
+				       struct jump_entry *stop)
+{
+	for (; (entry < stop) && (jump_entry_key(entry) == key); entry++) {
+		if (jump_label_can_update(entry, false))
+			arch_jump_label_transform_queue(entry,
+							jump_label_type(entry));
+	}
+}
+
+void jump_label_update_nosync(struct static_key *key)
+{
+	struct jump_entry *stop = __stop___jump_table;
+	struct jump_entry *entry;
+#ifdef CONFIG_MODULES
+	struct static_key_mod *mod;
+
+	if (static_key_linked(key)) {
+		for (mod = static_key_mod(key); mod; mod = mod->next) {
+			struct module *m;
+
+			if (!mod->entries)
+				continue;
+
+			m = mod->mod;
+			if (!m)
+				stop = __stop___jump_table;
+			else
+				stop = m->jump_entries + m->num_jump_entries;
+			__jump_label_update_nosync(key, mod->entries, stop);
+		}
+		return;
+	}
+
+	scoped_guard(rcu) {
+		struct module *m;
+
+		m = __module_address((unsigned long)key);
+		if (m)
+			stop = m->jump_entries + m->num_jump_entries;
+	}
+#endif
+	entry = static_key_entries(key);
+	if (!entry)
+		return;
+
+	__jump_label_update_nosync(key, entry, stop);
 }
 
 #ifdef CONFIG_STATIC_KEYS_SELFTEST


### PR DESCRIPTION
arm64 pseudo-NMI allows interrupts to punch through local_irq_disable()
by switching from DAIF-based to PMR-based interrupt masking.  Today this
is a boot-time decision requiring the irqchip.gicv3_pseudo_nmi=1 kernel
parameter, and it cannot be changed afterwards.

This series makes pseudo-NMI enableable and disableable at runtime via
debugfs, allowing on-demand NMI debugging without paying the PMR masking
overhead during normal operation.

The primary use case is diagnosing hard lockups on systems that
occasionally get stuck with interrupts disabled.  Pseudo-NMI must be
enabled before the lockup occurs -- once a CPU is stuck, it cannot
respond to the IPI needed for the masking switch.  Typical usage is to
enable it proactively when investigating a suspected lockup, then
disable it when no longer needed:

    # Enable before reproducing the suspected lockup
    echo 1 > /sys/kernel/debug/pseudo_nmi/enable

    # ... reproduce the issue ...
    # NMI backtraces now reach CPUs stuck with IRQs disabled
    echo l > /proc/sysrq-trigger

    # Disable when done debugging
    echo 0 > /sys/kernel/debug/pseudo_nmi/enable

Design:

The interrupt masking paradigm (DAIF vs PMR) is controlled by a static
branch rather than boot-time alternatives, giving zero overhead when
disabled (NOP/branch instructions, identical to the current alternatives
approach).

Switching the paradigm at runtime requires atomicity across all CPUs and
all call sites.  A mixed state where some sites use DAIF and others use
PMR would deadlock: a CPU could disable IRQs via one path and re-enable
via the other, leaving one mask permanently active.

The transition works by parking all remote CPUs in an IPI handler while
the master CPU patches all static branch sites under jump_label_lock.
Each CPU then transitions using a lock-new/unlock-old pattern: take the
new lock (PMR for enable, DAIF for disable) before releasing the old
one.

Since kernel_entry and kernel_exit straddle the transition (entry ran
before the patch, exit runs after), the IPI handlers fix up pt_regs to
convert the saved register state to the new format:
 - Enable: set pt_regs->pmr from the saved PSTATE (kernel_entry skipped
   PMR save)
 - Disable: set PSR_I_BIT in pt_regs->pstate from the saved PMR
   (kernel_entry saved PMR with DAIF.I clear)

After the masking switch, debug IPIs (backtrace, stop, kgdb) are
promoted from regular IRQ to NMI priority via teardown and
re-registration through request_percpu_nmi().

Demonstration:

The following test uses a module that spins with IRQs disabled on a
pinned CPU for 20 seconds, then triggers sysrq-l from another CPU 3
seconds into the spin.

Without pseudo-NMI, CPU 2 cannot respond to the backtrace IPI while
IRQs are disabled.  It only responds 17 seconds later after the spin
completes, showing handle_softirqs -- the lockup has already ended and
the actual location is lost:
```
  [   22.714363] test_irqoff: CPU2 disabling IRQs for 20000 ms NOW
  [   25.741183] sysrq: Show backtrace of all active CPUs
  [   25.741451] Sending NMI from CPU 3 to CPUs 0-2:
  [   25.741464] NMI backtrace for cpu 0 skipped: idling
  [   25.741476] NMI backtrace for cpu 1 skipped: idling
                                 <--- CPU 2 missing, no response
  ...
  [   42.714431] NMI backtrace for cpu 2
                                 <--- 17 seconds late, lockup over
  [   42.714456] pc : handle_softirqs+0xf4/0x680
  [   42.714521]  irqoff_thread+0x88/0x110 [test_irqoff] (P)
```
With pseudo-NMI enabled at runtime, CPU 2 responds immediately and
shows the exact function where it is stuck -- simulated_hard_lockup,
called from irqoff_thread with IRQs disabled:
```
  [   92.994150] Pseudo-NMI enabled at runtime
  [   93.012168] test_irqoff: CPU2 disabling IRQs for 20000 ms NOW
  [   96.041400] sysrq: Show backtrace of all active CPUs
  [   96.041622] Sending NMI from CPU 3 to CPUs 0-2:
  [   96.041714] NMI backtrace for cpu 2
                                 <--- immediate response
  [   96.041723] pc : arch_counter_get_cntvct+0x14/0x18
  [   96.041762]  simulated_hard_lockup+0x1c/0x40 [test_irqoff]
  [   96.041768]  irqoff_thread+0x68/0x110 [test_irqoff]
```